### PR TITLE
Update plugin.py for project-independent story URL

### DIFF
--- a/src/sentry_pivotal/plugin.py
+++ b/src/sentry_pivotal/plugin.py
@@ -73,6 +73,4 @@ class PivotalTrackerPlugin(IssuePlugin):
         return '#%s' % issue_id
 
     def get_issue_url(self, group, issue_id, **kwargs):
-        project = self.get_option('project', group.project)
-
-        return 'https://www.pivotaltracker.com/projects/%s/stories/%s' % (project, issue_id)
+        return 'https://www.pivotaltracker.com/story/show/%s' % (issue_id)


### PR DESCRIPTION
When Pivotal is configured for multiple projects, moving a created story to a different project will break the URL saved in Sentry. The story ID is unchanged, however, so we can use Pivotal's story-only routing for a more robust link.
